### PR TITLE
add template similarity to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ sorting_analyzer.compute("isi_histograms")
 sorting_analyzer.compute("correlograms", window_ms=100, bin_ms=5.)
 sorting_analyzer.compute("principal_components", n_components=3, mode='by_channel_global', whiten=True, **job_kwargs)
 sorting_analyzer.compute("quality_metrics", metric_names=["snr", "firing_rate"])
+sorting_analyzer.compute("template_similarity")
 sorting_analyzer.compute("spike_amplitudes", **job_kwargs)
 
 ```


### PR DESCRIPTION
```
Exception: The template_similarity waveform extension is required for this widget. Run the `sorting_analyzer.compute('template_similarity', ...)` to compute it.
```

add this to the readme to make it easier for new users.