### PR TITLE
Update WaveformView xrange using newly computed xvects

### DIFF
--- a/spikeinterface_gui/waveformview.py
+++ b/spikeinterface_gui/waveformview.py
@@ -386,8 +386,6 @@ class WaveformView(ViewBase):
 
         xvectors = self.xvect[common_channel_indexes, :] * self.factor_x
         xvects = self.get_xvectors_not_overlap(xvectors, len(visible_unit_ids))
-
-
         for (xvect, unit_index, unit_id) in zip(xvects, visible_unit_indices, visible_unit_ids):
             template_avg = self.controller.templates_average[unit_index, :, :][:, common_channel_indexes]
             
@@ -419,7 +417,7 @@ class WaveformView(ViewBase):
 
             x_margin =50
             y_margin =150
-            self._x_range = np.min(self.xvect) - x_margin , np.max(self.xvect) + x_margin
+            self._x_range = np.min(xvect) - x_margin , np.max(xvect) + x_margin
             visible_mask = self.controller.get_units_visibility_mask()
             visible_pos = self.controller.unit_positions[visible_mask, :]
             self._y1_range = np.min(visible_pos[:,1]) - y_margin , np.max(visible_pos[:,1]) + y_margin

--- a/spikeinterface_gui/waveformview.py
+++ b/spikeinterface_gui/waveformview.py
@@ -387,7 +387,7 @@ class WaveformView(ViewBase):
         xvectors = self.xvect[common_channel_indexes, :] * self.factor_x
         xvects = self.get_xvectors_not_overlap(xvectors, len(visible_unit_ids))
 
-        
+
         for (xvect, unit_index, unit_id) in zip(xvects, visible_unit_indices, visible_unit_ids):
             template_avg = self.controller.templates_average[unit_index, :, :][:, common_channel_indexes]
             

--- a/spikeinterface_gui/waveformview.py
+++ b/spikeinterface_gui/waveformview.py
@@ -386,6 +386,8 @@ class WaveformView(ViewBase):
 
         xvectors = self.xvect[common_channel_indexes, :] * self.factor_x
         xvects = self.get_xvectors_not_overlap(xvectors, len(visible_unit_ids))
+
+        
         for (xvect, unit_index, unit_id) in zip(xvects, visible_unit_indices, visible_unit_ids):
             template_avg = self.controller.templates_average[unit_index, :, :][:, common_channel_indexes]
             

--- a/spikeinterface_gui/waveformview.py
+++ b/spikeinterface_gui/waveformview.py
@@ -419,7 +419,7 @@ class WaveformView(ViewBase):
 
             x_margin =50
             y_margin =150
-            self._x_range = np.min(xvect) - x_margin , np.max(xvect) + x_margin
+            self._x_range = np.min(xvects) - x_margin , np.max(xvects) + x_margin
             visible_mask = self.controller.get_units_visibility_mask()
             visible_pos = self.controller.unit_positions[visible_mask, :]
             self._y1_range = np.min(visible_pos[:,1]) - y_margin , np.max(visible_pos[:,1]) + y_margin

--- a/spikeinterface_gui/waveformview.py
+++ b/spikeinterface_gui/waveformview.py
@@ -668,8 +668,8 @@ class WaveformView(ViewBase):
             self._panel_refresh_one_spike()
 
         if not keep_range:
-            self.figure_geom.x_range.start = np.min(self.xvect) - 50
-            self.figure_geom.x_range.end = np.max(self.xvect) + 50
+            self.figure_geom.x_range.start = np.min(xvects) - 50
+            self.figure_geom.x_range.end = np.max(xvects) + 50
             self.figure_geom.y_range.start = np.min(ypos) - 50
             self.figure_geom.y_range.end = np.max(ypos) + 50
 


### PR DESCRIPTION
Hello,

On a multi-shank probe, the xRange on the `WaveformView` wasn't updating when I selected a new unit.

I think I tracked down the problem: `self._x_range` should be computed using the newly computed  xvect (higher up in the function) rather than the one stored in `self`. 

Alternative solution: the new `xvects` should be stored in `self`??

(don't ask me how this took 4 commits...)