### PR TITLE
Keep track of position in unitlist while curating

### DIFF
--- a/spikeinterface_gui/unitlist.py
+++ b/spikeinterface_gui/unitlist.py
@@ -188,10 +188,17 @@ class UnitListView(ViewBase):
         
 
     def _qt_set_default_label(self, label):
+        from .utils_qt import CustomItem
         selected_unit_ids = self.get_selected_unit_ids()
         for unit_id in selected_unit_ids:
             self.controller.set_label_to_unit(unit_id, "quality", label)
-        self._qt_full_table_refresh()
+
+        selected_rows = self._qt_get_selected_rows()
+        for row in selected_rows:
+            item = CustomItem(label)
+            self.table.setItem(row, self.label_columns[0], item)
+        
+        self._qt_on_only_next_shortcut()
 
     def _qt_full_table_refresh(self):
         # TODO sam make this faster


### PR DESCRIPTION
On main qt: when you curate a unit by pressing "g", "n" or "m" the unitlist is totally refreshed and you lose your place.

This PR: you don't do a full refresh. You just save the labels, then apply `setItems` to the appropriate columns. Then apply a `_qt_on_only_next_shortcut`.

Makes curation seemless. The web version already does something like this.

Note: this works even when you've sorted your columns in a non-standard way.