### PR TITLE
Allow long zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,55 @@ cd spikeinterface-gui
 pip install .
 ```
 
-## Cedits
+## Custom layout
+
+You can create your own custom layout by specifying which views you'd like
+to see, and where they go. The basic window layout supports eight "zones",
+which are laid out as follows:
+
+```
++-----------------+-----------------+
+| [zone1   zone2] | [zone3 | [zone4 |
++-----------------+        |        +
+| [zone5   zone6] | zone7] | zone8] |
++-----------------+-----------------+
+```
+
+If zones are not included, the other zones take over their space. Hence if you'd
+like to show waveforms as a long view, you can set zone3 to display waveforms
+and then set zone7 to display nothing. The waveforms in zone3 will take over the
+blank space from zone7.
+
+To specify your own layout, put the specification in a `.json` file. This should
+be a list of zones, and which views should appear in which zones. An example:
+
+
+**my_layout.json**
+```
+{
+    "zone1": ["unitlist", "spikelist"], 
+    "zone2": ["spikeamplitude"], 
+    "zone3": ["waveform", "waveformheatmap"], 
+    "zone4": ["similarity"], 
+    "zone5": ["spikedepth"], 
+    "zone6": [], 
+    "zone7": [], 
+    "zone8": ["correlogram"]
+}
+```
+
+When you open spikeinterface-gui, you can then point to the `my_layout.json`
+using the `--layout_file` flag:
+
+```
+sigui --layout_file=path/to/my_layout.json path/to/sorting_analyzer
+```
+
+Find a list of available views [in this file](https://github.com/SpikeInterface/spikeinterface-gui/blob/main/spikeinterface_gui/viewlist.py).
+
+
+
+## Credits
 
 Original author : Samuel Garcia, CNRS, Lyon, France
 

--- a/spikeinterface_gui/backend_qt.py
+++ b/spikeinterface_gui/backend_qt.py
@@ -222,25 +222,25 @@ class QtMainWindow(QT.QMainWindow):
                     self.splitDockWidget(self.docks[first_left], dock, orientations['vertical'])
 
         ## Handle right
-        first_left = None
-        for zone in ['zone3', 'zone7', 'zone4',  'zone8']:
+        first_top = None
+        for zone in ['zone3', 'zone4', 'zone7',  'zone8']:
             if len(widgets_zone[zone]) == 0:
                 continue
             view_name = widgets_zone[zone][0]
             dock = self.docks[view_name]
-            if len(widgets_zone[zone]) > 0 and first_left is None:
+            if len(widgets_zone[zone]) > 0 and first_top is None:
                 self.addDockWidget(areas['right'], dock)
-                first_left = view_name
-            elif zone == 'zone7':
-                self.splitDockWidget(self.docks[first_left], dock, orientations['vertical'])
+                first_top = view_name
             elif zone == 'zone4':
-                self.splitDockWidget(self.docks[first_left], dock, orientations['horizontal'])
+                self.splitDockWidget(self.docks[first_top], dock, orientations['horizontal'])
+            elif zone == 'zone7':
+                self.splitDockWidget(self.docks[first_top], dock, orientations['vertical'])
             elif zone == 'zone8':
-                if len(widgets_zone['zone7']) > 0:
-                    z = widgets_zone['zone7'][0]
-                    self.splitDockWidget(self.docks[z], dock, orientations['horizontal'])
+                if len(widgets_zone['zone4']) > 0:
+                    z = widgets_zone['zone4'][0]
+                    self.splitDockWidget(self.docks[z], dock, orientations['vertical'])
                 else:
-                    self.splitDockWidget(self.docks[first_left], dock, orientations['vertical'])
+                    self.splitDockWidget(self.docks[first_top], dock, orientations['horizontal'])
         
         # make tabs
         for zone, view_names in widgets_zone.items():

--- a/spikeinterface_gui/layout_presets.py
+++ b/spikeinterface_gui/layout_presets.py
@@ -2,9 +2,9 @@
 A preset need 8 zones like this:
 
 +-----------------+-----------------+
-| [zone1   zone2] | [zone3   zone4] |
-+-----------------+-----------------+
-| [zone5   zone6] | [zone7   zone8] |
+| [zone1   zone2] | [zone3 | [zone4 |
++-----------------+        |        +
+| [zone5   zone6] | zone7] | zone8] |
 +-----------------+-----------------+
 
 """


### PR DESCRIPTION
A suggestion:

Change the layout possibilities from:

```
+-----------------+-----------------+
| [zone1   zone2] | [zone3   zone4] |
+-----------------+-----------------+
| [zone5   zone6] | [zone7   zone8] |
+-----------------+-----------------+
```

to

```
+-----------------+-----------------+
| [zone1   zone2] | [zone3 | [zone4 |
+-----------------+        |        +
| [zone5   zone6] | zone7] | zone8] |
+-----------------+-----------------+
```

Mostly, this allows for a vertical waveforms view without having to use up four zones. So you're able to get layouts like this:

<img width="1470" height="956" alt="Screenshot 2025-07-24 at 12 09 57" src="https://github.com/user-attachments/assets/ec931c04-c6d0-4570-b53b-5b845c07fb7f" />

If you agree, I'll implement for web too!