### PR TITLE
Add option to include layout json

### DIFF
--- a/spikeinterface_gui/layout_presets.py
+++ b/spikeinterface_gui/layout_presets.py
@@ -9,11 +9,30 @@ A preset need 8 zones like this:
 
 """
 
+from spikeinterface_gui.backend_qt import possible_class_views
 _presets = {}
-def get_layout_description(preset_name, layout_dict=None):
-    if layout_dict is not None:
+
+def _check_valid_layout_dict(layout_dict):
+    for key, class_views in layout_dict.items():
+        if key not in [f"zone{a}" for a in range(1,9)]:
+            raise KeyError(f"Key {key} in layout dictionary not equal to zone1, zone2, ... or zone8.")
+        for class_view in class_views:
+            list_of_possible_class_views = list(possible_class_views.keys())
+            if class_view not in list_of_possible_class_views:
+                raise KeyError(f"View '{class_view}' in layout dictionary not equal to a valid View. "\
+                                "Valid views are {list_of_possible_class_views}")
+
+def get_layout_description(preset_name, layout=None):
+    if isinstance(layout, dict):
+        _check_valid_layout_dict(layout)
         # If a layout_dict is provided, use it instead of the preset
-        return layout_dict
+        return layout
+    elif isinstance(layout, str):
+        if layout.endswith('json'):
+            import json
+            with open(layout) as layout_file:
+                layout_dict = json.load(layout_file)
+            return get_layout_description(None, layout=layout_dict)
     else:
         if preset_name is None:
             preset_name = 'default'

--- a/spikeinterface_gui/layout_presets.py
+++ b/spikeinterface_gui/layout_presets.py
@@ -1,3 +1,6 @@
+import json
+from spikeinterface_gui.backend_qt import possible_class_views
+
 """
 A preset need 8 zones like this:
 
@@ -8,8 +11,6 @@ A preset need 8 zones like this:
 +-----------------+-----------------+
 
 """
-
-from spikeinterface_gui.backend_qt import possible_class_views
 _presets = {}
 
 def _check_valid_layout_dict(layout_dict):
@@ -29,7 +30,6 @@ def get_layout_description(preset_name, layout=None):
         return layout
     elif isinstance(layout, str):
         if layout.endswith('json'):
-            import json
             with open(layout) as layout_file:
                 layout_dict = json.load(layout_file)
             return get_layout_description(None, layout=layout_dict)

--- a/spikeinterface_gui/main.py
+++ b/spikeinterface_gui/main.py
@@ -251,7 +251,8 @@ def run_mainwindow_cli():
     parser.add_argument('--verbose', help='Make the output verbose', action='store_true', default=False)
     parser.add_argument('--port', help='Port for web mode', default=0, type=int)
     parser.add_argument('--address', help='Address for web mode', default='localhost')
-    
+    parser.add_argument('--layout_file', help='Path to json file defining layout', default=None)
+
     args = parser.parse_args(argv)
 
     analyzer_folder = args.analyzer_folder
@@ -292,5 +293,6 @@ def run_mainwindow_cli():
             with_traces=not(args.no_traces),
             curation=args.curation,
             recording=recording,
-            verbose=args.verbose
+            verbose=args.verbose,
+            layout=args.layout_file,
         )


### PR DESCRIPTION
Allows you to run e.g.
``sigui --layout_file=my_layout.json ~/Work/my_projects/si_talk/M25_D18/kilosort4_sa``
where if your json looks like this:

```
{
    "zone1": ["spikeamplitude"], 
    "zone2": [], 
    "zone3": ["waveform"], 
    "zone4": ["similarity"], 
    "zone5": ["unitlist"], 
    "zone6": ["correlogram"], 
    "zone7": ["spikedepth"], 
    "zone8": []
}
```

you get a GUI that looks like this:

<img width="1058" height="617" alt="Screenshot 2025-07-28 at 15 33 15" src="https://github.com/user-attachments/assets/5dd1eb26-9563-4011-8e23-e855794f5fc2" />

Works for web too!

Also added checks to verify that the keys and values in the json file are valid (and does this check if you programatically pass a dict).

Will add docs if you agree with the PR, and after we debate #163.
