### PR TITLE
Pin pyside6, remove PyQt6 and update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,31 +170,19 @@ For beginners or Anaconda users please see our [installation tips](https://githu
 where we provide a yaml for Mac/Windows/Linux to help properly install `spikeinterface` and `spikeinterface-gui` for you in a dedicated
 conda environment.
 
-Otherwise, 
-
-You need first to install **one** of these 3 packages (by order of preference):
-  * `pip install PySide6` or
-  * `pip install PyQt6` or
-  * `pip install PyQt5`
-
-From pypi:
+In your environment, if you wish to use the Desktop version of the GUI, you can do:
 
 ```bash
-pip install spikeinterface-gui
+pip install 'spikeinterface-gui[desktop]'
 ```
 
-For Desktop you can do:
+Note: this installs `PySide6`. You can use the `PyQt5` backend instead by uninstalling `PySide6` and then installing `PyQt5`.
+
+If you wish to use the Web version of the GUI, you can do:
 
 ```bash
-pip install spikeinterface-gui[desktop]
+pip install 'spikeinterface-gui[web]'
 ```
-
-For web you can do:
-
-```bash
-pip install spikeinterface-gui[web]
-```
-
 
 From source:
 
@@ -203,6 +191,8 @@ git clone https://github.com/SpikeInterface/spikeinterface-gui.git
 cd spikeinterface-gui
 pip install .
 ```
+
+You'll then need to install the appropriate backends yourself (`pyqtgraph` and `PySide6` or `PyQt5` for the desktop; `panel` and `bokeh` for web).
 
 ## Custom layout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ sigui = "spikeinterface_gui.main:run_mainwindow_cli"
 [project.optional-dependencies]
 
 desktop = [
-    "PySide6",
+    "PySide6==6.7.3",
     "pyqtgraph",
 ]
 
@@ -55,5 +55,5 @@ web = [
 
 test = [
     "pytest",
-    "PySide6",
+    "PySide6==6.7.3",
 ]

--- a/spikeinterface_gui/myqt.py
+++ b/spikeinterface_gui/myqt.py
@@ -39,14 +39,6 @@ if QT_MODE is None:
 
 if QT_MODE is None:
     try:
-        import PyQt6
-        from PyQt6 import QtCore, QtGui, QtWidgets
-        QT_MODE = 'PyQt6'
-    except ImportError:
-        pass
-
-if QT_MODE is None:
-    try:
         import PyQt5
         from PyQt5 import QtCore, QtGui, QtWidgets
         QT_MODE = 'PyQt5'
@@ -56,8 +48,6 @@ if QT_MODE is None:
 #~ print(QT_MODE)
 
 if QT_MODE == 'PySide6':
-    QT = ModuleProxy(['', 'Q', 'Qt'], [QtCore.Qt, QtCore, QtGui, QtWidgets])
-elif QT_MODE == 'PyQt6':
     QT = ModuleProxy(['', 'Q', 'Qt'], [QtCore.Qt, QtCore, QtGui, QtWidgets])
 elif QT_MODE == 'PyQt5':
     QT = ModuleProxy(['', 'Q', 'Qt'], [QtCore.Qt, QtCore, QtGui, QtWidgets])


### PR DESCRIPTION
PySide6 only works for me at version 6.7.3. This PR pins the version number.
PyQt6 doesn't work at all. This PR removes it!

Also update the install instrucitons, so users are more likely to see the e.g. `pip install 'spikeinterface-gui[desktop]` instruction rather than `pip install 'spikeinterface-gui` followed by messing around with other packages. Feedback welcome.

Fixes #150