### PR TITLE
Add binned spikes view

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,31 +170,19 @@ For beginners or Anaconda users please see our [installation tips](https://githu
 where we provide a yaml for Mac/Windows/Linux to help properly install `spikeinterface` and `spikeinterface-gui` for you in a dedicated
 conda environment.
 
-Otherwise, 
-
-You need first to install **one** of these 3 packages (by order of preference):
-  * `pip install PySide6` or
-  * `pip install PyQt6` or
-  * `pip install PyQt5`
-
-From pypi:
+In your environment, if you wish to use the Desktop version of the GUI, you can do:
 
 ```bash
-pip install spikeinterface-gui
+pip install 'spikeinterface-gui[desktop]'
 ```
 
-For Desktop you can do:
+Note: this installs `PySide6`. You can use the `PyQt5` backend instead by uninstalling `PySide6` and then installing `PyQt5`.
+
+If you wish to use the Web version of the GUI, you can do:
 
 ```bash
-pip install spikeinterface-gui[desktop]
+pip install 'spikeinterface-gui[web]'
 ```
-
-For web you can do:
-
-```bash
-pip install spikeinterface-gui[web]
-```
-
 
 From source:
 
@@ -203,6 +191,8 @@ git clone https://github.com/SpikeInterface/spikeinterface-gui.git
 cd spikeinterface-gui
 pip install .
 ```
+
+You'll then need to install the appropriate backends yourself (`pyqtgraph` and `PySide6` or `PyQt5` for the desktop; `panel` and `bokeh` for web).
 
 ## Custom layout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ sigui = "spikeinterface_gui.main:run_mainwindow_cli"
 [project.optional-dependencies]
 
 desktop = [
-    "PySide6",
+    "PySide6==6.7.3",
     "pyqtgraph",
 ]
 
@@ -55,5 +55,5 @@ web = [
 
 test = [
     "pytest",
-    "PySide6",
+    "PySide6==6.7.3",
 ]

--- a/spikeinterface_gui/myqt.py
+++ b/spikeinterface_gui/myqt.py
@@ -39,14 +39,6 @@ if QT_MODE is None:
 
 if QT_MODE is None:
     try:
-        import PyQt6
-        from PyQt6 import QtCore, QtGui, QtWidgets
-        QT_MODE = 'PyQt6'
-    except ImportError:
-        pass
-
-if QT_MODE is None:
-    try:
         import PyQt5
         from PyQt5 import QtCore, QtGui, QtWidgets
         QT_MODE = 'PyQt5'
@@ -56,8 +48,6 @@ if QT_MODE is None:
 #~ print(QT_MODE)
 
 if QT_MODE == 'PySide6':
-    QT = ModuleProxy(['', 'Q', 'Qt'], [QtCore.Qt, QtCore, QtGui, QtWidgets])
-elif QT_MODE == 'PyQt6':
     QT = ModuleProxy(['', 'Q', 'Qt'], [QtCore.Qt, QtCore, QtGui, QtWidgets])
 elif QT_MODE == 'PyQt5':
     QT = ModuleProxy(['', 'Q', 'Qt'], [QtCore.Qt, QtCore, QtGui, QtWidgets])


### PR DESCRIPTION
Add a binned spikes view, which plots the binned spikes. Default bin size is one minute. Helpful to see oversplitting.

Enjjoy viewing a unit on your desktop app

<img width="1853" height="1168" alt="Screenshot from 2025-08-20 09-57-59" src="https://github.com/user-attachments/assets/f18a457e-d9ab-4550-9bde-37e54f41f0b6" />

Or view a couple on the web:

<img width="1170" height="427" alt="Screenshot from 2025-08-20 09-59-44" src="https://github.com/user-attachments/assets/0c6e066b-0ca6-4426-a48d-25a8637595e1" />
