### PR TITLE
Update ScatterView range

### DIFF
--- a/spikeinterface_gui/basescatterview.py
+++ b/spikeinterface_gui/basescatterview.py
@@ -111,13 +111,11 @@ class BaseScatterView(ViewBase):
         self.viewBox = ViewBoxHandlingLasso()
         self.viewBox.lasso_drawing.connect(self.on_lasso_drawing)
         self.viewBox.lasso_finished.connect(self.on_lasso_finished)
-        self.viewBox.disableAutoRange()
         self.plot = pg.PlotItem(viewBox=self.viewBox)
         self.graphicsview.setCentralItem(self.plot)
         self.plot.hideButtons()
     
         self.viewBox2 = ViewBoxHandlingLasso()
-        self.viewBox2.disableAutoRange()
         self.plot2 = pg.PlotItem(viewBox=self.viewBox2)
         self.graphicsview2.setCentralItem(self.plot2)
         self.plot2.hideButtons()
@@ -128,8 +126,7 @@ class BaseScatterView(ViewBase):
         self.plot.addItem(self.scatter)
         
         self._text_items = []
-        
-        self.plot.setYRange(self._data_min,self._data_max, padding = 0.0)
+
 
     def _qt_on_spike_selection_changed(self):
         self.refresh()
@@ -162,11 +159,13 @@ class BaseScatterView(ViewBase):
             max_count = max(max_count, np.max(hist_count))
 
         self._max_count = max_count
-        seg_index =  self.combo_seg.currentIndex()
-        time_max = self.controller.get_num_samples(seg_index) / self.controller.sampling_frequency
-
-        self.plot.setXRange( 0., time_max, padding = 0.0)
+        
+        self.plot.getViewBox().autoRange(padding = 0.0)
         self.plot2.setXRange(0, self._max_count, padding = 0.0)
+
+        # explicitly set the y-range of the histogram to match the spike data
+        y_range_plot_1 = self.plot.getViewBox().viewRange()
+        self.viewBox2.setYRange(y_range_plot_1[1][0], y_range_plot_1[1][1], padding = 0.0)
         
         spike_times, spike_data = self.get_selected_spikes_data()
         self.scatter_select.setData(spike_times, spike_data)


### PR DESCRIPTION
Changes the way the `BaseScatterView` updates its range. Desktop behaviour now matches the web behaviour.

Two changes:
1. The scatter plot now uses `autoRange`,
2. then the histogram updates its y-range to match the scatter plot. This should fix #171 

Previously, both plots used min(all_data) max(all_data) for the y-range. Hence a single large-amplitude spike could make the plot go very gross.