### PR TITLE
Add `curation-file` arg and fix unit quality from CurationModel

### DIFF
--- a/spikeinterface_gui/controller.py
+++ b/spikeinterface_gui/controller.py
@@ -773,7 +773,7 @@ class Controller():
             return
         for merge_index in merge_group_indices:
             if self.verbose:
-                print(f"Unmerged merge group {self.curation_data['merge_unit_groups'][merge_index]['unit_ids']}")
+                print(f"Unmerged merge group {self.curation_data['merges'][merge_index]['unit_ids']}")
             self.curation_data["merges"].pop(merge_index)
 
     def get_curation_label_definitions(self):
@@ -794,9 +794,10 @@ class Controller():
         if ix is None:
             return
         lbl = self.curation_data["manual_labels"][ix]
-        if category in lbl:
-            labels = lbl[category]
-            return labels[0]
+        if 'labels' in lbl: 
+            if category in lbl['labels']:
+                labels = lbl['labels'][category]
+                return labels[0]
 
     def set_label_to_unit(self, unit_id, category, label):
         if label is None:

--- a/spikeinterface_gui/main.py
+++ b/spikeinterface_gui/main.py
@@ -260,6 +260,7 @@ def run_mainwindow_cli():
     parser.add_argument('--port', help='Port for web mode', default=0, type=int)
     parser.add_argument('--address', help='Address for web mode', default='localhost')
     parser.add_argument('--layout-file', help='Path to json file defining layout', default=None)
+    parser.add_argument('--curation-file', help='Path to json file defining a curation', default=None)
 
     args = parser.parse_args(argv)
 
@@ -295,6 +296,12 @@ def run_mainwindow_cli():
                         raise ValueError('The recording does not have the same channel ids as the analyzer')
                     recording = recording.select_channels(recording.channel_ids[channel_mask])
 
+        if args.curation_file is not None:
+            with open(args.curation_file, "r") as f:
+                curation_data = json.load(f)
+        else:
+            curation_data = None
+
         run_mainwindow(
             analyzer,
             mode=args.mode,
@@ -303,4 +310,5 @@ def run_mainwindow_cli():
             recording=recording,
             verbose=args.verbose,
             layout=args.layout_file,
+            curation_dict=curation_data,
         )


### PR DESCRIPTION
Been playing with curation and an auto-curation algorithm. Would be great to add a `curation-file` arg - useful for me to visually check the algorithm with different parameters.

Also fixes the bug @alejoe91 mentioned yesterday, where quality labels were not being fed into `UnitView`.