### PR TITLE
Greedy layout idea

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,22 +200,27 @@ You can create your own custom layout by specifying which views you'd like
 to see, and where they go. The basic window layout supports eight "zones",
 which are laid out as follows:
 
-```
-+-----------------+-----------------+
-| [zone1   zone2] | [zone3 | [zone4 |
-+-----------------+        |        +
-| [zone5   zone6] | zone7] | zone8] |
-+-----------------+-----------------+
-```
++---------------+--------------+
+| zone1   zone2 | zone3  zone4 |
++               +              +
+| zone5   zone6 | zone7  zone8 |
++---------------+--------------+
 
-If zones are not included, the other zones take over their space. Hence if you'd
-like to show waveforms as a long view, you can set zone3 to display waveforms
-and then set zone7 to display nothing. The waveforms in zone3 will take over the
-blank space from zone7.
+If a zone has free space below it or to the right of it, it will try to use it.
+Stretching downwards takes precedence over stretching rightwards.
+E.g. suppose your layout is only non-empty in zones 1, 4, 5, 6 and 7:
+
++---------------+--------------+
+| zone1         |        zone4 |
++               +              +
+| zone5   zone6 | zone7        |
++---------------+--------------+
+
+Then zone1 will stretch right-wards to make a three-zone view. Zone4 will stretch
+downwards to make a long two-zone view.
 
 To specify your own layout, put the specification in a `.json` file. This should
 be a list of zones, and which views should appear in which zones. An example:
-
 
 **my_layout.json**
 ```

--- a/spikeinterface_gui/backend_panel.py
+++ b/spikeinterface_gui/backend_panel.py
@@ -4,7 +4,8 @@ import numpy as np
 from copy import copy
 
 from .viewlist import possible_class_views
-from .layout_presets import get_layout_description, get_size_bottom_row, get_size_top_row
+from .layout_presets import get_layout_description
+from .utils_global import get_size_bottom_row, get_size_top_row
 
 # Used by views to emit/trigger signals
 class SignalNotifier(param.Parameterized):

--- a/spikeinterface_gui/backend_panel.py
+++ b/spikeinterface_gui/backend_panel.py
@@ -4,7 +4,7 @@ import numpy as np
 from copy import copy
 
 from .viewlist import possible_class_views
-from .layout_presets import get_layout_description
+from .layout_presets import get_layout_description, get_size_bottom_row, get_size_top_row
 
 # Used by views to emit/trigger signals
 class SignalNotifier(param.Parameterized):
@@ -182,49 +182,6 @@ def create_settings(view):
 def listen_setting_changes(view):
     for setting_data in view._settings:
         view.settings._parameterized.param.watch(view.on_settings_changed, setting_data["name"])
-
-def get_size_top_row(initial_row, initial_col, is_zone_array, original_zone_array):
-    
-    if original_zone_array[initial_row][initial_col] == False:
-        return 0,0
-
-    num_rows = is_zone_array[initial_row][initial_col]*1
-    num_cols = num_rows
-
-    num_rows += (not is_zone_array[1][initial_col])*1
-
-    if num_rows == 1:
-        for zone in is_zone_array[0,1+initial_col:]:
-            if zone == True:
-                break
-            num_cols += 1
-    elif num_rows == 2:
-        for zone1, zone2 in np.transpose(is_zone_array[:,1+initial_col:]):
-            if zone1 == True or zone2 == True:
-                break
-            num_cols += 1
-
-    is_zone_array[initial_row:initial_row+num_rows,initial_col:initial_col+num_cols] = True
-
-    return num_rows, num_cols
-
-def get_size_bottom_row(initial_row, initial_col, is_zone_array, original_zone_array):
-    
-    if original_zone_array[initial_row][initial_col] == False:
-        return 0,0
-    
-    num_rows = is_zone_array[initial_row][initial_col]*1
-    if num_rows == 0:
-        return 0, 0
-    num_cols = num_rows
-
-    for zone in is_zone_array[1,1+initial_col:]:
-        if zone == True:
-            break
-        else:
-            num_cols += 1
-
-    return num_rows, num_cols
 
 class PanelMainWindow:
 

--- a/spikeinterface_gui/backend_panel.py
+++ b/spikeinterface_gui/backend_panel.py
@@ -282,22 +282,28 @@ class PanelMainWindow:
             allow_drag=False,
         )
 
-        all_zones = [f'zone{a}' for a in range(1,9)]
+        gs = self.make_half_layout(gs, ['zone1', 'zone2', 'zone5', 'zone6'], layout_zone, 0)
+        gs = self.make_half_layout(gs, ['zone3', 'zone4', 'zone7', 'zone8'], layout_zone, 2)
+
+        self.main_layout = gs
+
+    def make_half_layout(self, gs, all_zones, layout_zone, shift):
+
         is_zone = [(layout_zone.get(zone) is not None) and (len(layout_zone.get(zone)) > 0) for zone in all_zones]
-        is_zone_array = np.reshape(is_zone, (2,4))
+        is_zone_array = np.reshape(is_zone, (2,2))
         original_zone_array = copy(is_zone_array)
 
-        for zone_index in range(8):
-            row = zone_index // 4
-            col = zone_index % 4
+        for zone_index, zone_name in enumerate(all_zones):
+            row = zone_index // 2
+            col = zone_index % 2
             if row == 0:
                 num_rows, num_cols = get_size_top_row(row, col, is_zone_array, original_zone_array)
             elif row == 1:
                 num_rows, num_cols = get_size_bottom_row(row, col, is_zone_array, original_zone_array)
             if num_rows > 0 and num_cols > 0:
-                gs[slice(row, row + num_rows), slice(col,col+num_cols)] = layout_zone.get(f'zone{zone_index+1}')
+                gs[slice(row, row + num_rows), slice(col+shift,col+num_cols+shift)] = layout_zone.get(zone_name)
 
-        self.main_layout = gs
+        return gs
 
     def update_visibility(self, event):
         active = event.new

--- a/spikeinterface_gui/backend_qt.py
+++ b/spikeinterface_gui/backend_qt.py
@@ -249,7 +249,7 @@ class QtMainWindow(QT.QMainWindow):
                     bottom_zone = f"zone{column_index+5}"
                     widgets_zone[top_zone] = widgets_zone[bottom_zone]
                     widgets_zone[bottom_zone] = []
-                break
+                    continue
 
         is_zone = np.array([(widgets_zone.get(zone) is not None) and (len(widgets_zone.get(zone)) > 0) for zone in all_zones])
         is_zone_array = np.reshape(is_zone, (2,4))

--- a/spikeinterface_gui/backend_qt.py
+++ b/spikeinterface_gui/backend_qt.py
@@ -136,7 +136,7 @@ def listen_setting_changes(view):
 class QtMainWindow(QT.QMainWindow):
     main_window_closed = QT.pyqtSignal(object)
 
-    def __init__(self, controller, parent=None, layout_preset=None, layout=None, screenshot_name=""):
+    def __init__(self, controller, parent=None, layout_preset=None, layout=None):
         QT.QMainWindow.__init__(self, parent)
         
         self.controller = controller
@@ -152,16 +152,6 @@ class QtMainWindow(QT.QMainWindow):
             # refresh do not work because view are not yet visible at init
             view._refresh()
         self.controller.signal_handler.activate()
-
-        self.screenshot_name = screenshot_name
-        #QT.QTimer.singleShot(200, self.saveScreenshot)
-
-    def saveScreenshot(self):
-
-        screen = QT.QApplication.primaryScreen()
-        screenshot = screen.grabWindow( self.winId() )
-        screenshot.save(self.screenshot_name, 'jpg')
-
         # TODO sam : all veiws are always refreshed at the moment so this is useless.
         # uncommen this when ViewBase.is_view_visible() work correctly
         # for view_name, dock in self.docks.items():

--- a/spikeinterface_gui/backend_qt.py
+++ b/spikeinterface_gui/backend_qt.py
@@ -249,6 +249,7 @@ class QtMainWindow(QT.QMainWindow):
                     bottom_zone = f"zone{column_index+5}"
                     widgets_zone[top_zone] = widgets_zone[bottom_zone]
                     widgets_zone[bottom_zone] = []
+                break
 
         is_zone = np.array([(widgets_zone.get(zone) is not None) and (len(widgets_zone.get(zone)) > 0) for zone in all_zones])
         is_zone_array = np.reshape(is_zone, (2,4))

--- a/spikeinterface_gui/backend_qt.py
+++ b/spikeinterface_gui/backend_qt.py
@@ -1,7 +1,8 @@
 from .myqt import QT
 import pyqtgraph as pg
 import markdown
-
+import numpy as np
+from copy import copy
 
 import weakref
 
@@ -233,9 +234,6 @@ class QtMainWindow(QT.QMainWindow):
             # keep only instantiated views
             view_names = [view_name for view_name in view_names if view_name in self.views.keys()]
             widgets_zone[zone] = view_names
-
-        import numpy as np
-        from copy import copy
 
         all_zones = [f'zone{a}' for a in range(1,9)]
         all_zones_array = np.transpose(np.reshape(all_zones, (2,4)))

--- a/spikeinterface_gui/backend_qt.py
+++ b/spikeinterface_gui/backend_qt.py
@@ -7,7 +7,8 @@ from copy import copy
 import weakref
 
 from .viewlist import possible_class_views
-from .layout_presets import get_layout_description, get_size_bottom_row, get_size_top_row
+from .layout_presets import get_layout_description
+from .utils_global import get_size_bottom_row, get_size_top_row
 
 from .utils_qt import qt_style, add_stretch_to_qtoolbar
 

--- a/spikeinterface_gui/backend_qt.py
+++ b/spikeinterface_gui/backend_qt.py
@@ -200,8 +200,8 @@ class QtMainWindow(QT.QMainWindow):
             view_names = [view_name for view_name in view_names if view_name in self.views.keys()]
             widgets_zone[zone] = view_names
 
-        self.make_dock(widgets_zone, ['zone1', 'zone2', 'zone5', 'zone6'], "left")
-        self.make_dock(widgets_zone, ['zone3', 'zone4', 'zone7', 'zone8'], "right")
+        self.make_dock(widgets_zone, ['zone1', 'zone2', 'zone5', 'zone6'], "left", col_shift=0)
+        self.make_dock(widgets_zone, ['zone3', 'zone4', 'zone7', 'zone8'], "right", col_shift=2)
         
         # make tabs
         for zone, view_names in widgets_zone.items():
@@ -217,7 +217,7 @@ class QtMainWindow(QT.QMainWindow):
             # make visible the first of each zone
             self.docks[view_name0].raise_()
 
-    def make_dock(self, widgets_zone, all_zones, side_of_window):
+    def make_dock(self, widgets_zone, all_zones, side_of_window, col_shift):
 
         all_zones_array = np.transpose(np.reshape(all_zones, (2,2)))
         is_zone = np.array([(widgets_zone.get(zone) is not None) and (len(widgets_zone.get(zone)) > 0) for zone in all_zones])
@@ -228,8 +228,8 @@ class QtMainWindow(QT.QMainWindow):
             if np.any(zones_in_columns):
                 first_is_top = zones_in_columns[0]
                 if not first_is_top:
-                    top_zone = f"zone{column_index+1}"
-                    bottom_zone = f"zone{column_index+5}"
+                    top_zone = f"zone{column_index+1+col_shift}"
+                    bottom_zone = f"zone{column_index+5+col_shift}"
                     widgets_zone[top_zone] = widgets_zone[bottom_zone]
                     widgets_zone[bottom_zone] = []
                     continue
@@ -247,7 +247,7 @@ class QtMainWindow(QT.QMainWindow):
             is_a_zone = original_zone_array[:,col]            
             num_row_0, _ = get_size_top_row(0, col, is_zone_array, original_zone_array)
             # this function affects is_zone_array so must be run
-            _, _ = get_size_bottom_row(0, col, is_zone_array, original_zone_array)
+            _, _ = get_size_bottom_row(1, col, is_zone_array, original_zone_array)
             
             if num_row_0 == 2:
                 if len(group) > 0:
@@ -261,6 +261,9 @@ class QtMainWindow(QT.QMainWindow):
 
         if len(group) > 0:
             all_groups.append(group)
+
+        if len(all_groups) == 0:
+            return
 
         first_zone = all_groups[0][0]
         first_dock = widgets_zone[first_zone][0]

--- a/spikeinterface_gui/curation_tools.py
+++ b/spikeinterface_gui/curation_tools.py
@@ -14,7 +14,7 @@ empty_curation_data = {
     "manual_labels": [],
     "merges": [],
     "splits": [],
-    "removes": []
+    "removed": []
 }
 
 def add_merge(previous_merges, new_merge_unit_ids):

--- a/spikeinterface_gui/layout_presets.py
+++ b/spikeinterface_gui/layout_presets.py
@@ -1,5 +1,6 @@
 import json
 from spikeinterface_gui.viewlist import possible_class_views
+import numpy as np
 
 """
 A preset depends on eight zones. 
@@ -51,6 +52,49 @@ def get_layout_description(preset_name, layout=None):
             preset_name = 'default'
         return _presets[preset_name]
 
+
+def get_size_top_row(initial_row, initial_col, is_zone_array, original_zone_array):
+    
+    if original_zone_array[initial_row][initial_col] == False:
+        return 0,0
+
+    num_rows = is_zone_array[initial_row][initial_col]*1
+    num_cols = num_rows
+
+    num_rows += (not is_zone_array[1][initial_col])*1
+
+    if num_rows == 1:
+        for zone in is_zone_array[0,1+initial_col:]:
+            if zone == True:
+                break
+            num_cols += 1
+    elif num_rows == 2:
+        for zone1, zone2 in np.transpose(is_zone_array[:,1+initial_col:]):
+            if zone1 == True or zone2 == True:
+                break
+            num_cols += 1
+
+    is_zone_array[initial_row:initial_row+num_rows,initial_col:initial_col+num_cols] = True
+
+    return num_rows, num_cols
+
+def get_size_bottom_row(initial_row, initial_col, is_zone_array, original_zone_array):
+    
+    if original_zone_array[initial_row][initial_col] == False:
+        return 0,0
+    
+    num_rows = is_zone_array[initial_row][initial_col]*1
+    if num_rows == 0:
+        return 0, 0
+    num_cols = num_rows
+
+    for zone in is_zone_array[1,1+initial_col:]:
+        if zone == True:
+            break
+        else:
+            num_cols += 1
+
+    return num_rows, num_cols
 
 default_layout = dict(
     zone1=['curation', 'spikelist'],

--- a/spikeinterface_gui/layout_presets.py
+++ b/spikeinterface_gui/layout_presets.py
@@ -2,14 +2,27 @@ import json
 from spikeinterface_gui.viewlist import possible_class_views
 
 """
-A preset need 8 zones like this:
+A preset depends on eight zones. 
 
-+-----------------+-----------------+
-| [zone1   zone2] | [zone3 | [zone4 |
-+-----------------+        |        +
-| [zone5   zone6] | zone7] | zone8] |
-+-----------------+-----------------+
++---------------+--------------+
+| zone1   zone2   zone3  zone4 |
++               +              +
+| zone5   zone6   zone7  zone8 |
++---------------+--------------+
 
+If a zone has free space below it or to the right of it, it will try to use it.
+E.g. suppose your layout is only non-empty in zones 1, 4, 5, 6 and 7:
+
++---------------+--------------+
+| zone1                  zone4 |
++               +              +
+| zone5   zone6   zone7        |
++---------------+--------------+
+
+Then zone1 will stretch right-wards to make a three-zone view. Zone4 will stretch
+downwards to make a long two-zone view.
+
+If there is not a unique way to fill the gaps, some space will be left unused.
 """
 _presets = {}
 

--- a/spikeinterface_gui/layout_presets.py
+++ b/spikeinterface_gui/layout_presets.py
@@ -12,6 +12,7 @@ A preset depends on eight zones.
 +---------------+--------------+
 
 If a zone has free space below it or to the right of it, it will try to use it.
+Stretching downwards takes precedence over stretching rightwards.
 E.g. suppose your layout is only non-empty in zones 1, 4, 5, 6 and 7:
 
 +---------------+--------------+

--- a/spikeinterface_gui/layout_presets.py
+++ b/spikeinterface_gui/layout_presets.py
@@ -53,50 +53,6 @@ def get_layout_description(preset_name, layout=None):
             preset_name = 'default'
         return _presets[preset_name]
 
-
-def get_size_top_row(initial_row, initial_col, is_zone_array, original_zone_array):
-    
-    if original_zone_array[initial_row][initial_col] == False:
-        return 0,0
-
-    num_rows = is_zone_array[initial_row][initial_col]*1
-    num_cols = num_rows
-
-    num_rows += (not is_zone_array[1][initial_col])*1
-
-    if num_rows == 1:
-        for zone in is_zone_array[0,1+initial_col:]:
-            if zone == True:
-                break
-            num_cols += 1
-    elif num_rows == 2:
-        for zone1, zone2 in np.transpose(is_zone_array[:,1+initial_col:]):
-            if zone1 == True or zone2 == True:
-                break
-            num_cols += 1
-
-    is_zone_array[initial_row:initial_row+num_rows,initial_col:initial_col+num_cols] = True
-
-    return num_rows, num_cols
-
-def get_size_bottom_row(initial_row, initial_col, is_zone_array, original_zone_array):
-    
-    if original_zone_array[initial_row][initial_col] == False:
-        return 0,0
-    
-    num_rows = is_zone_array[initial_row][initial_col]*1
-    if num_rows == 0:
-        return 0, 0
-    num_cols = num_rows
-
-    for zone in is_zone_array[1,1+initial_col:]:
-        if zone == True:
-            break
-        else:
-            num_cols += 1
-
-    return num_rows, num_cols
-
 default_layout = dict(
     zone1=['curation', 'spikelist'],
     zone2=['unitlist', 'mergelist'],

--- a/spikeinterface_gui/layout_presets.py
+++ b/spikeinterface_gui/layout_presets.py
@@ -3,12 +3,12 @@ from spikeinterface_gui.viewlist import possible_class_views
 import numpy as np
 
 """
-A preset depends on eight zones. 
+A preset depends on eight zones, which are split into two sub-regions
 
 +---------------+--------------+
-| zone1   zone2   zone3  zone4 |
+| zone1   zone2 | zone3  zone4 |
 +               +              +
-| zone5   zone6   zone7  zone8 |
+| zone5   zone6 | zone7  zone8 |
 +---------------+--------------+
 
 If a zone has free space below it or to the right of it, it will try to use it.
@@ -16,15 +16,13 @@ Stretching downwards takes precedence over stretching rightwards.
 E.g. suppose your layout is only non-empty in zones 1, 4, 5, 6 and 7:
 
 +---------------+--------------+
-| zone1                  zone4 |
+| zone1         |        zone4 |
 +               +              +
-| zone5   zone6   zone7        |
+| zone5   zone6 | zone7        |
 +---------------+--------------+
 
 Then zone1 will stretch right-wards to make a three-zone view. Zone4 will stretch
 downwards to make a long two-zone view.
-
-If there is not a unique way to fill the gaps, some space will be left unused.
 """
 _presets = {}
 

--- a/spikeinterface_gui/main.py
+++ b/spikeinterface_gui/main.py
@@ -30,6 +30,7 @@ def run_mainwindow(
     panel_start_server_kwargs=None,
     panel_window_servable=True,
     verbose=False,
+    screenshot_name=""
 ):
     """
     Create the main window and start the QT app loop.
@@ -121,8 +122,8 @@ def run_mainwindow(
 
 
         app = mkQApp()
-        
-        win = QtMainWindow(controller, layout_preset=layout_preset, layout=layout)
+
+        win = QtMainWindow(controller, layout_preset=layout_preset, layout=layout, screenshot_name=screenshot_name)
         win.setWindowTitle('SpikeInterface GUI')
         # Set window icon
         icon_file = Path(__file__).absolute().parent / 'img' / 'si.png'
@@ -273,7 +274,7 @@ def run_mainwindow_cli():
         if args.verbose:
             print('Loading analyzer...')
         assert check_folder_is_analyzer(analyzer_folder), f'The folder {analyzer_folder} is not a valid SortingAnalyzer folder'
-        analyzer = load_sorting_analyzer(analyzer_folder, load_extensions=not is_path_remote(analyzer_folder))
+        analyzer = load_sorting_analyzer(analyzer_folder, load_extensions=False)
         if args.verbose:
             print('Analyzer loaded')
 
@@ -312,3 +313,4 @@ def run_mainwindow_cli():
             layout=args.layout_file,
             curation_dict=curation_data,
         )
+

--- a/spikeinterface_gui/main.py
+++ b/spikeinterface_gui/main.py
@@ -30,7 +30,6 @@ def run_mainwindow(
     panel_start_server_kwargs=None,
     panel_window_servable=True,
     verbose=False,
-    screenshot_name=""
 ):
     """
     Create the main window and start the QT app loop.
@@ -123,7 +122,7 @@ def run_mainwindow(
 
         app = mkQApp()
 
-        win = QtMainWindow(controller, layout_preset=layout_preset, layout=layout, screenshot_name=screenshot_name)
+        win = QtMainWindow(controller, layout_preset=layout_preset, layout=layout)
         win.setWindowTitle('SpikeInterface GUI')
         # Set window icon
         icon_file = Path(__file__).absolute().parent / 'img' / 'si.png'

--- a/spikeinterface_gui/utils_global.py
+++ b/spikeinterface_gui/utils_global.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+def get_size_top_row(initial_row, initial_col, is_zone_array, original_zone_array):
+    
+    if original_zone_array[initial_row][initial_col] == False:
+        return 0,0
+
+    num_rows = is_zone_array[initial_row][initial_col]*1
+    num_cols = num_rows
+
+    num_rows += (not is_zone_array[1][initial_col])*1
+
+    if num_rows == 1:
+        for zone in is_zone_array[0,1+initial_col:]:
+            if zone == True:
+                break
+            num_cols += 1
+    elif num_rows == 2:
+        for zone1, zone2 in np.transpose(is_zone_array[:,1+initial_col:]):
+            if zone1 == True or zone2 == True:
+                break
+            num_cols += 1
+
+    is_zone_array[initial_row:initial_row+num_rows,initial_col:initial_col+num_cols] = True
+
+    return num_rows, num_cols
+
+def get_size_bottom_row(initial_row, initial_col, is_zone_array, original_zone_array):
+    
+    if original_zone_array[initial_row][initial_col] == False:
+        return 0,0
+    
+    num_rows = is_zone_array[initial_row][initial_col]*1
+    if num_rows == 0:
+        return 0, 0
+    num_cols = num_rows
+
+    for zone in is_zone_array[1,1+initial_col:]:
+        if zone == True:
+            break
+        else:
+            num_cols += 1
+
+    return num_rows, num_cols


### PR DESCRIPTION
PR to make layouts _even more_ flexible.

The layout idea is described as follows in the layout presets docstring:

```
"""
A preset depends on eight zones. 

+---------------+--------------+
| zone1   zone2   zone3  zone4 |
+               +              +
| zone5   zone6   zone7  zone8 |
+---------------+--------------+

If a zone has free space below it or to the right of it, it will try to use it.
E.g. suppose your layout is only non-empty in zones 1, 4, 5, 6 and 7:

+---------------+--------------+
| zone1                  zone4 |
+               +              +
| zone5   zone6   zone7        |
+---------------+--------------+

Then zone1 will stretch right-wards to make a three-zone view. Zone4 will stretch
downwards to make a long two-zone view.

If there is not a unique way to fill the gaps, some space will be left unused.
"""
```

Quite easy to update the panel implementation - have a go!

This should allow long waveforms for Chris and wide traces for Sam.