### PR TITLE
Update `delta_x` calculation to improve WaveformView

### DIFF
--- a/spikeinterface_gui/waveformview.py
+++ b/spikeinterface_gui/waveformview.py
@@ -35,11 +35,20 @@ class WaveformView(ViewBase):
         self.contact_location = self.controller.get_contact_location().copy()
         xpos = self.contact_location[:,0]
         ypos = self.contact_location[:,1]
-        unique_x = np.sort(np.unique(np.round(xpos)))
-        if unique_x.size>1:
-            self.delta_x = np.min(np.diff(unique_x))
+
+        # copied directly from spikeinterface.widgets.unit_waveform
+        manh = np.abs(
+            self.contact_location[None, :] - self.contact_location[:, None]
+        )  # vertical and horizontal distances between each channel
+        eucl = np.linalg.norm(manh, axis=2)  # Euclidean distance matrix
+        np.fill_diagonal(eucl, np.inf)  # the distance of a channel to itself is not considered
+        gaus = np.exp(-0.5 * (eucl / eucl.min()) ** 2)  # sigma uses the min distance between channels
+        weight = manh[..., 0] / eucl * gaus
+        if weight.sum() == 0:
+            self.delta_x = 10
         else:
-            self.delta_x = 40. # um
+            self.delta_x = (manh[..., 0] * weight).sum() / weight.sum()
+
         unique_y = np.sort(np.unique(np.round(ypos)))
         if unique_y.size>1:
             self.delta_y = np.min(np.diff(unique_y))


### PR DESCRIPTION
Fixes #190 by updating the `delta_x` calculation, to match spikeinterface's.

I made a repo to help do visual testing: https://github.com/chrishalcrow/sigui_visual_tests
Aim of the repo: easily create screenshots of sigui to test out PRs for a variety of input data. Should be easy to try out. Try it!!!

Should also be super easy to test out other `delta_x` ideas too, since this one is good but quite complex.

You should compare these screenshots with the ones here: https://github.com/chrishalcrow/sigui_visual_tests/tree/main/screenshots/waveformview_main

<img width="1296" height="1076" alt="nn64_one_unit" src="https://github.com/user-attachments/assets/4303de2f-000d-4363-be1c-46e05a74b1df" />
<img width="1296" height="1076" alt="NP1_one_unit" src="https://github.com/user-attachments/assets/78c37117-1e2d-4475-8d74-5720726b140e" />
<img width="1296" height="1076" alt="NP2_one_unit" src="https://github.com/user-attachments/assets/18c09ed5-36f7-459c-b7d7-99fb1ffd6b10" />
<img width="1296" height="1076" alt="tetrode_one_unit" src="https://github.com/user-attachments/assets/bf9182dc-8b6c-4148-aa2e-8ada021747fb" />
