### PR TITLE
Don't save `UnitList` settings

### DIFF
--- a/spikeinterface_gui/mainsettingsview.py
+++ b/spikeinterface_gui/mainsettingsview.py
@@ -54,6 +54,9 @@ class MainSettingsView(ViewBase):
             view_class_name = view.__class__.__name__
             view_name = view_class_name.replace("View", "").lower()
 
+            if view_name == "unitlist":
+                continue
+
             settings_dict[view_name] = {}
 
             if backend == "panel":


### PR DESCRIPTION
At the moment, when you save default settings this saves the `UnitList` settings. These are the columns you've selected to display like the quality metrics and are automatically generated from the quality metrics extension.

This is a problem. If you first open an analyzer with LOTS of metrics computed, save the default settings, then open an analyzer with no metrics computed it errors, because the analyzer with no metrics doesn't know about the metrics from the analyzer with lots of metrics.

I think it's easiest to not save any settings from the unitlist, since these aren't "real" settings: it's just which columns are displayed. This way you can still choose which metrics to display in your user settings, which is nice.