### PR TITLE
Fix check for recording using `has_extension('recording')`

### DIFF
--- a/spikeinterface_gui/controller.py
+++ b/spikeinterface_gui/controller.py
@@ -420,7 +420,7 @@ class Controller():
 
     def update_time_info(self):
         # set default time info
-        if self.main_settings["use_times"] and self.analyzer.has_recording():
+        if self.main_settings["use_times"] and self.has_extension("recording"):
             time_by_seg=np.array(
                 [
                     self.analyzer.recording.get_start_time(segment_index) for segment_index in range(self.num_segments)
@@ -439,7 +439,7 @@ class Controller():
 
     def get_t_start_t_stop(self):
         segment_index = self.time_info["segment_index"]
-        if self.main_settings["use_times"] and self.analyzer.has_recording():
+        if self.main_settings["use_times"] and self.has_extension("recording"):
             t_start = self.analyzer.recording.get_start_time(segment_index=segment_index)
             t_stop = self.analyzer.recording.get_end_time(segment_index=segment_index)
             return t_start, t_stop
@@ -471,7 +471,7 @@ class Controller():
 
     def sample_index_to_time(self, sample_index):
         segment_index = self.time_info["segment_index"]
-        if self.main_settings["use_times"] and self.analyzer.has_recording():
+        if self.main_settings["use_times"] and self.has_extension("recording"):
             time = self.analyzer.recording.sample_index_to_time(sample_index, segment_index=segment_index)
             return time
         else:
@@ -479,7 +479,7 @@ class Controller():
 
     def time_to_sample_index(self, time):
         segment_index = self.time_info["segment_index"]
-        if self.main_settings["use_times"] and self.analyzer.has_recording():
+        if self.main_settings["use_times"] and self.has_extension("recording"):
             time = self.analyzer.recording.time_to_sample_index(time, segment_index=segment_index)
             return time
         else:

--- a/spikeinterface_gui/mainsettingsview.py
+++ b/spikeinterface_gui/mainsettingsview.py
@@ -43,8 +43,6 @@ class MainSettingsView(ViewBase):
         self.controller.main_settings['use_times'] = self.main_settings['use_times']
         self.controller.update_time_info()
         self.notify_use_times_updated()
-        # for view in self.controller.views:
-        #     view.refresh()
 
     def save_current_settings(self, event=None):
         

--- a/spikeinterface_gui/traceview.py
+++ b/spikeinterface_gui/traceview.py
@@ -586,7 +586,7 @@ class TraceView(ViewBase, MixinViewTrace):
         self.figure.yaxis.visible = False
 
         # Add data sources
-        self.signal_source = ColumnDataSource({"xs": [], "ys": [], "channel_id": []})
+        self.signal_source = ColumnDataSource({"xs": [], "ys": []})
 
         self.spike_source = ColumnDataSource({"x": [], "y": [], "color": []})
 
@@ -625,7 +625,6 @@ class TraceView(ViewBase, MixinViewTrace):
             self.signal_source.data.update({
                 "xs": [[]],
                 "ys": [[]],
-                "channel_id": [],
             })
             self.spike_source.data.update({
                 "x": [],
@@ -642,7 +641,6 @@ class TraceView(ViewBase, MixinViewTrace):
                 {
                     "xs": [times_chunk]*n,
                     "ys": [data_curves[i, :] for i in range(n)],
-                    "channel_id": self.get_visible_channel_inds(),
                 }
             )
 


### PR DESCRIPTION
and a tiny fix to `TraceView` in panel when no channels are selected

`has_extension("recording")` supports both recordings and temporary recordings, so it's more robust