### PR TITLE
Allow for analyzer without noise levels to display amplitudes, and fix amps bug

### DIFF
--- a/spikeinterface_gui/spikeamplitudeview.py
+++ b/spikeinterface_gui/spikeamplitudeview.py
@@ -55,7 +55,7 @@ class SpikeAmplitudeView(BaseScatterView):
         alpha_factor = 50 / n
         self.noise_harea=[]
         for i in range(1, n + 1):
-            self.plot2.addItem(
+            noise_bar = self.plot2.addItem(
                 pg.LinearRegionItem(
                     values=(-i * noise, i * noise),
                     orientation="horizontal",
@@ -63,7 +63,7 @@ class SpikeAmplitudeView(BaseScatterView):
                     pen=(0, 0, 0, 0),
                 )
             )
-            self.noise_harea.append(i)
+            self.noise_harea.append(noise_bar)
 
     def _panel_make_layout(self):
         self.noise_sources = []


### PR DESCRIPTION
Currently if an analyzer has `spike_amplitudes` but no `noise_levels`, the gui errors. This fixes that.

Also, there was a bug where the noise levels were not being plotted sometimes. The `refresh` in BaseScatterView clears `self.plot2`, so we always need to do `_qt_add_noise_area`, if we can.