### PR TITLE
Fix label read curation

### DIFF
--- a/spikeinterface_gui/controller.py
+++ b/spikeinterface_gui/controller.py
@@ -372,7 +372,6 @@ class Controller():
                         print('Curation quality labels are the default ones')
                     self.has_default_quality_labels = True
 
-
     def check_is_view_possible(self, view_name):
         from .viewlist import possible_class_views
         view_class = possible_class_views[view_name]
@@ -988,7 +987,7 @@ class Controller():
             if category in lbl:
                 lbl[category] = [label]
             else:
-                lbl[category] = [label]            
+                lbl[category] = [label]
         else:
             lbl = {"unit_id": unit_id, category:[label]}
             self.curation_data["manual_labels"].append(lbl)


### PR DESCRIPTION
`get_unit_label`, used to display labels from a curation dict was assuming the form

``` python
curation['manual_labels'] = [{'unit_id': 1, 'labels': {'quality': ['good']}}]
```

rather than

``` python
curation['manual_labels'] = [{'unit_id': 1,  'quality': ['good']}]
```

meaning that if you passed a curation dict with quality labels, they were not showing up.