### PR TITLE
Add `external_data` to controller

### DIFF
--- a/spikeinterface_gui/controller.py
+++ b/spikeinterface_gui/controller.py
@@ -34,10 +34,23 @@ from spikeinterface.widgets.sorting_summary import _default_displayed_unit_prope
 
 
 class Controller():
-    def __init__(self, analyzer=None, backend="qt", parent=None, verbose=False, save_on_compute=False,
-                 curation=False, curation_data=None, label_definitions=None, with_traces=True,
-                 displayed_unit_properties=None,
-                 extra_unit_properties=None, skip_extensions=None, disable_save_settings_button=False):
+    def __init__(
+        self,
+        analyzer=None,
+        backend="qt",
+        parent=None,
+        verbose=False,
+        save_on_compute=False,
+        curation=False,
+        curation_data=None,
+        label_definitions=None,
+        with_traces=True,
+        displayed_unit_properties=None,
+        extra_unit_properties=None,
+        skip_extensions=None,
+        disable_save_settings_button=False,
+        external_data=None,
+    ):
         self.views = []
         skip_extensions = skip_extensions if skip_extensions is not None else []
 
@@ -45,6 +58,7 @@ class Controller():
         self.backend = backend
         self.disable_save_settings_button = disable_save_settings_button
         self.current_curation_saved = True
+        self.external_data = external_data
 
         if self.backend == "qt":
             from .backend_qt import SignalHandler

--- a/spikeinterface_gui/main.py
+++ b/spikeinterface_gui/main.py
@@ -36,6 +36,7 @@ def run_mainwindow(
     verbose=False,
     user_settings=None,
     disable_save_settings_button=False,
+    external_data=None,
 ):
     """
     Create the main window and start the QT app loop.
@@ -92,6 +93,9 @@ def run_mainwindow(
         A dictionary of user settings for each view, which overwrite the default settings.
     disable_save_settings_button: bool, default: False
         If True, disables the "save default settings" button, so that user cannot do this.
+    external_data: object, default: None
+        Whatever is passed to `external_data` is attached to the controller as the attribute
+        `external_data`. Useful for custom views.
     """
 
     if mode == "desktop":
@@ -129,14 +133,18 @@ def run_mainwindow(
         skip_extensions = find_skippable_extensions(layout_dict)
 
     controller = Controller(
-        analyzer, backend=backend, verbose=verbose,
-        curation=curation, curation_data=curation_dict,
+        analyzer,
+        backend=backend,
+        verbose=verbose,
+        curation=curation,
+        curation_data=curation_dict,
         label_definitions=label_definitions,
         with_traces=with_traces,
         displayed_unit_properties=displayed_unit_properties,
         extra_unit_properties=extra_unit_properties,
         skip_extensions=skip_extensions,
-        disable_save_settings_button=disable_save_settings_button
+        disable_save_settings_button=disable_save_settings_button,
+        external_data=external_data,
     )
     if verbose:
         t1 = time.perf_counter()


### PR DESCRIPTION
Using this in the lab to view behavioral data in a custom plugin using the gui (colour scheme my own, which everyone else in the lab hates)!

<img width="1591" height="1021" alt="Screenshot from 2026-01-30 12-00-58" src="https://github.com/user-attachments/assets/a5c39e7e-3253-4d85-a6d4-1b8edfe21f6f" />
