### PR TITLE
Fix time range for old template metric analyzers

### DIFF
--- a/spikeinterface_gui/maintemplateview.py
+++ b/spikeinterface_gui/maintemplateview.py
@@ -68,6 +68,7 @@ class MainTemplateView(ViewBase):
 
             if template_high is None:
                 template_high = template
+                self.time_vect_high = self.time_vect
                 plot_template = False
             else:
                 plot_template = True
@@ -180,6 +181,7 @@ class MainTemplateView(ViewBase):
 
             if template_high is None:
                 template_high = template
+                self.time_vect_high = self.time_vect
                 plot_template = False
             else:
                 plot_template = True


### PR DESCRIPTION
Oups. We messed up support for pre-si-0.104 analyzers in `MainTemplatesView`.