### PR TITLE
Only init views in layout dict

### DIFF
--- a/spikeinterface_gui/backend_qt.py
+++ b/spikeinterface_gui/backend_qt.py
@@ -185,8 +185,12 @@ class QtMainWindow(QT.QMainWindow):
     def make_views(self, user_settings):
         self.views = {}
         self.docks = {}
+        views_per_zone = list(self.layout_dict.values())
+        user_selected_views = [view for views_in_zone in views_per_zone for view in views_in_zone]
         possible_class_views = get_all_possible_views()
         for view_name, view_class in possible_class_views.items():
+            if view_name not in user_selected_views:
+                continue
             if 'qt' not in view_class._supported_backend:
                 continue
             if not self.controller.check_is_view_possible(view_name):


### PR DESCRIPTION
At the moment, in QT, we init all views then only display the ones the user has chosen. This PR skips `init`ing views which are not in the layout.

Problem arose when I was making a plug-in that required external_data on init (actually, I could move that aware from the init...). But seems sensible in general!