### PR TITLE
Update channel visibility when unit is changed in unitview

### DIFF
--- a/spikeinterface_gui/traceview.py
+++ b/spikeinterface_gui/traceview.py
@@ -394,13 +394,11 @@ class MixinViewTrace:
 
         bottom_bar_items = [self.time_slider]
         if self.controller.has_extension("events"):
-            self.event_line = None
-            if self.controller.has_extension("events"):
-                self.event_source = ColumnDataSource({"xs": [], "ys": []})
-                self.event_line = self.figure.multi_line(
-                    source=self.event_source,
-                    xs="xs", ys="ys", line_color="yellow", line_dash="dashed", line_width=2, line_alpha=0.8
-                )
+            self.event_source = ColumnDataSource({"xs": [], "ys": []})
+            self.event_line = self.figure.multi_line(
+                source=self.event_source,
+                xs="xs", ys="ys", line_color="yellow", line_dash="dashed", line_width=2, line_alpha=0.8
+            )
             event_keys = list(self.controller.events.keys())
             if len(event_keys) > 1:
                 self.event_selector = pn.widgets.Select(
@@ -581,9 +579,6 @@ class MixinViewTrace:
         fig = self.figure
         yspan = [fig.y_range.start, fig.y_range.end]
         self.event_source.data = {"xs": [[evt_time, evt_time]], "ys": [yspan]}
-
-    def _panel_remove_event_line(self):
-        self.event_source.data = {"xs": [], "ys": []}
 
     # TODO: pan behavior like Qt?
     # def _panel_on_pan_start(self, event):
@@ -828,6 +823,10 @@ class TraceView(ViewBase, MixinViewTrace):
             x="x", y="y", size=10, fill_color="color", fill_alpha=self.settings['alpha'], source=self.spike_source
         )
 
+        # Placeholder for events
+        self.event_line = None
+        self.event_source = None
+
         self.figure.on_event(DoubleTap, self._panel_on_double_tap)
 
         self._panel_create_toolbars()
@@ -842,7 +841,6 @@ class TraceView(ViewBase, MixinViewTrace):
 
 
     def _panel_refresh(self):
-        self._panel_remove_event_line()
         t, segment_index = self.controller.get_time()
         xsize = self.xsize
         t1, t2 = t - xsize / 3.0, t + xsize * 2 / 3.0

--- a/spikeinterface_gui/unitlistview.py
+++ b/spikeinterface_gui/unitlistview.py
@@ -32,6 +32,13 @@ class UnitListView(ViewBase):
         elif self.backend == 'panel':
             self._panel_update_labels()
 
+    def notify_unit_visibility_changed(self):
+        selected_units = self.controller.get_visible_unit_ids()
+        visible_channel_inds = self.controller.get_common_sparse_channels(selected_units)
+        self.controller.set_channel_visibility(visible_channel_inds)
+        self.notify_channel_visibility_changed()
+        super().notify_unit_visibility_changed()
+
     ## Qt ##
     def _qt_make_layout(self):
         

--- a/spikeinterface_gui/unitlistview.py
+++ b/spikeinterface_gui/unitlistview.py
@@ -32,13 +32,6 @@ class UnitListView(ViewBase):
         elif self.backend == 'panel':
             self._panel_update_labels()
 
-    def notify_unit_visibility_changed(self):
-        selected_units = self.controller.get_visible_unit_ids()
-        visible_channel_inds = self.controller.get_common_sparse_channels(selected_units)
-        self.controller.set_channel_visibility(visible_channel_inds)
-        self.notify_channel_visibility_changed()
-        super().notify_unit_visibility_changed()
-
     ## Qt ##
     def _qt_make_layout(self):
         

--- a/spikeinterface_gui/unitlistview.py
+++ b/spikeinterface_gui/unitlistview.py
@@ -333,8 +333,11 @@ class UnitListView(ViewBase):
             is_visible = item.checkState() == QT.Qt.Checked
             # visibility checkbox
             unit_id = item.unit_id
+            current_visible_units = self.controller.get_visible_unit_ids()
             self.controller.set_unit_visibility(unit_id, is_visible)
-            self.notify_unit_visibility_changed()
+            updated_visibile_units = self.controller.get_visible_unit_ids()
+            if set(current_visible_units) != set(updated_visibile_units):
+                self.notify_unit_visibility_changed()
 
 
         elif col in self.label_columns:
@@ -349,12 +352,12 @@ class UnitListView(ViewBase):
 
     def _qt_on_double_clicked(self, row, col):
         unit_id = self.table.item(row, 1).unit_id
+        current_visible_units = self.controller.get_visible_unit_ids()
         self.controller.set_visible_unit_ids([unit_id])
-        # self.refresh()
-        
-
-        self.notify_unit_visibility_changed()
-        self._qt_refresh_visibility_items()
+        updated_visibile_units = self.controller.get_visible_unit_ids()
+        if set(current_visible_units) != set(updated_visibile_units):
+            self.notify_unit_visibility_changed()
+            self._qt_refresh_visibility_items()
     
     def _qt_on_open_context_menu(self):
         self.menu.popup(self.qt_widget.cursor().pos())
@@ -376,13 +379,15 @@ class UnitListView(ViewBase):
     def _qt_on_visible_shortcut(self):
         rows = self._qt_get_selected_rows()
 
+        current_visible_units = self.controller.get_visible_unit_ids()
         self.controller.set_visible_unit_ids(self.get_selected_unit_ids())
-        # self.refresh()
-        self.notify_unit_visibility_changed()
-        self._qt_refresh_visibility_items()
-        
-        for row in rows:
-            self.table.selectRow(row)
+        updated_visibile_units = self.controller.get_visible_unit_ids()
+        if set(current_visible_units) != set(updated_visibile_units):
+            self.notify_unit_visibility_changed()
+            self._qt_refresh_visibility_items()
+
+            for row in rows:
+                self.table.selectRow(row)
 
     def _qt_on_only_previous_shortcut(self):
         sel_rows = self._qt_get_selected_rows()
@@ -390,12 +395,14 @@ class UnitListView(ViewBase):
             sel_rows = [self.table.rowCount()]
         new_row = max(sel_rows[0] - 1, 0)
         unit_id = self.table.item(new_row, 1).unit_id
+        current_visible_units = self.controller.get_visible_unit_ids()
         self.controller.set_visible_unit_ids([unit_id])
-        self.notify_unit_visibility_changed()
-        self._qt_refresh_visibility_items()
-
-        self.table.clearSelection()
-        self.table.selectRow(new_row)
+        updated_visibile_units = self.controller.get_visible_unit_ids()
+        if set(current_visible_units) != set(updated_visibile_units):
+            self.notify_unit_visibility_changed()
+            self._qt_refresh_visibility_items()
+            self.table.clearSelection()
+            self.table.selectRow(new_row)
 
     def _qt_on_only_next_shortcut(self):
         sel_rows = self._qt_get_selected_rows()
@@ -403,11 +410,14 @@ class UnitListView(ViewBase):
             sel_rows = [-1]
         new_row = min(sel_rows[-1] + 1, self.table.rowCount() - 1)
         unit_id = self.table.item(new_row, 1).unit_id
+        current_visible_units = self.controller.get_visible_unit_ids()
         self.controller.set_visible_unit_ids([unit_id])
-        self.notify_unit_visibility_changed()
-        self._qt_refresh_visibility_items()
-        self.table.clearSelection()
-        self.table.selectRow(new_row)
+        updated_visibile_units = self.controller.get_visible_unit_ids()
+        if set(current_visible_units) != set(updated_visibile_units):
+            self.notify_unit_visibility_changed()
+            self._qt_refresh_visibility_items()
+            self.table.clearSelection()
+            self.table.selectRow(new_row)
 
     def _qt_on_delete_shortcut(self):
         sel_rows = self._qt_get_selected_rows()
@@ -735,13 +745,16 @@ class UnitListView(ViewBase):
     def _panel_on_only_selection(self):
         selected_unit = self.table.selection[0]
         unit_id = self.table.value.index.values[selected_unit]
+        current_visible_units = self.controller.get_visible_unit_ids()
         self.controller.set_visible_unit_ids([unit_id])
-        self._panel_refresh_colors()
-        # update the visible column
-        df = self.table.value
-        df.loc[self.controller.unit_ids, "visible"] = self.controller.get_units_visibility_mask()
-        self.table.value = df
-        self.notify_unit_visibility_changed()
+        updated_visibile_units = self.controller.get_visible_unit_ids()
+        if set(current_visible_units) != set(updated_visibile_units):
+            self._panel_refresh_colors()
+            # update the visible column
+            df = self.table.value
+            df.loc[self.controller.unit_ids, "visible"] = self.controller.get_units_visibility_mask()
+            self.table.value = df
+            self.notify_unit_visibility_changed()
 
     def _panel_get_selected_unit_ids(self):
         unit_ids = self.table.value.index.values
@@ -792,9 +805,12 @@ class UnitListView(ViewBase):
                 if self.controller.curation:
                     self._panel_merge_units()
             elif event.data == "visible":
+                current_visibile_units = self.controller.get_visible_unit_ids()
                 self.controller.set_visible_unit_ids(selected_unit_ids)
-                self.notify_unit_visibility_changed()
-                self.refresh()
+                updated_visibile_units = self.controller.get_visible_unit_ids()
+                if set(current_visibile_units) != set(updated_visibile_units):
+                    self.notify_unit_visibility_changed()
+                    self.refresh()
             elif event.data == "clear":
                 for unit_id in selected_unit_ids:
                     self.controller.set_label_to_unit(unit_id, "quality", None)


### PR DESCRIPTION
Bit of a big bug.

When we changed unit selection in unitview, the channel visibility was not updated. Hence traceview didn't have the right channels selected. I checked back to version 0.10 and it's been broken at least since then(!!). Note: if you select a unit through ProbeView, everything worked ok.