### PR TITLE
Fix quality curation when other labels are given by user

### DIFF
--- a/spikeinterface_gui/backend_panel.py
+++ b/spikeinterface_gui/backend_panel.py
@@ -431,8 +431,8 @@ class PanelMainWindow:
 
         curation_view = self.views["curation"]
         self.controller.set_curation_data(curation_data)
-        self.controller.current_curation_saved = True
         curation_view.notify_manual_curation_updated()
+        self.controller.current_curation_saved = True
         curation_view.refresh()
 
         # we also need to refresh the unit list view to update the unit visibility according to the new curation

--- a/spikeinterface_gui/controller.py
+++ b/spikeinterface_gui/controller.py
@@ -900,7 +900,7 @@ class Controller():
             new_curation_data["label_definitions"] = default_label_definitions.copy()
 
         # validate the curation data
-        model = CurationModel(**new_curation_data)
+        model = Curation(**new_curation_data)
         self.curation_data = model.model_dump()
 
     def save_curation_in_analyzer(self):


### PR DESCRIPTION
Found an awkward bug. If a user gives an external curation with some other labels, then you curate quality manually, the `curation_data` is not updated! This means if you run this:

``` python
import spikeinterface.full as si
from spikeinterface_gui import run_mainwindow
rec, sort = si.generate_ground_truth_recording(num_units=4)
sorting_analyzer = si.create_sorting_analyzer(sort, rec)
sorting_analyzer.compute('random_spikes')

manual_labels = []
for unit_id in sorting_analyzer.unit_ids:
    manual_labels.append({
        "unit_id": unit_id, 
        "brain_area": ["brain"],
    })
    
label_definitions = {
    "quality": dict(name="quality", label_options=["good", "MUA", "noise"], exclusive=True),
    "brain_area": dict(name="brain_area", label_options=["brain", "not_brain"], exclusive=True),
}

curation_dict = dict(
    format_version="2",
    unit_ids=sorting_analyzer.unit_ids,
    manual_labels=manual_labels,
    label_definitions=label_definitions,
)

run_mainwindow(
    sorting_analyzer,
    curation_dict=curation_dict,
    curation=True,
    displayed_unit_properties=['brain_area', 'quality']
)
```
then curate, then e.g. save curation json, the quality labels are not saved!!

I think this comes down to a bug in `set_label_to_unit`, which this PR fixes.

@alejoe91 can you check this PR works with some of your curation callback stuff?