### PR TITLE
Fix unit visibility change not propagating to other views

### DIFF
--- a/spikeinterface_gui/controller.py
+++ b/spikeinterface_gui/controller.py
@@ -600,7 +600,7 @@ class Controller():
 
     def get_visible_unit_ids(self):
         """Get list of visible unit_ids"""
-        return self._visible_unit_ids
+        return list(self._visible_unit_ids)
 
     def get_visible_unit_indices(self):
         """Get list of indices of visible units"""


### PR DESCRIPTION
## Summary
- `get_visible_unit_ids()` returned a direct reference to the internal `_visible_unit_ids` list
- Callers that snapshot before/after `set_unit_visibility()` to detect changes were comparing the same mutated object, so the comparison always found no difference
- This prevented `notify_unit_visibility_changed()` from firing, causing other widgets (waveforms, ISI, correlograms, etc.) to not refresh when toggling unit visibility in the unit list
- Fix: return `list(self._visible_unit_ids)` instead of the raw reference

## Test plan
- [ ] Open spikeinterface-gui with a sorting analyzer
- [ ] Toggle unit visibility checkboxes in the unit list
- [ ] Verify that other widgets (waveform, ISI, correlogram, probe, etc.) update automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)