### PR TITLE
Simplify if cond: return True/False else: return False/True patterns

### DIFF
--- a/spikeinterface_gui/curationview.py
+++ b/spikeinterface_gui/curationview.py
@@ -598,24 +598,15 @@ class CurationView(ViewBase):
 
     def _conditional_refresh_merge(self):
         # Check if the view is active before refreshing
-        if self.is_view_active() and self.active_table == "merge":
-            return True
-        else:
-            return False
+        return self.is_view_active() and self.active_table == "merge"
 
     def _conditional_refresh_delete(self):
         # Check if the view is active before refreshing
-        if self.is_view_active() and self.active_table == "delete":
-            return True
-        else:
-            return False
+        return self.is_view_active() and self.active_table == "delete"
 
     def _conditional_refresh_split(self):
         # Check if the view is active before refreshing
-        if self.is_view_active() and self.active_table == "split":
-            return True
-        else:
-            return False
+        return self.is_view_active() and self.active_table == "split"
 
 
 CurationView._gui_help_txt = """

--- a/spikeinterface_gui/main.py
+++ b/spikeinterface_gui/main.py
@@ -293,10 +293,7 @@ def check_folder_is_analyzer(folder):
         # Check if the folder contains the necessary files for a SortingAnalyzer
         with open(spikeinterface_info_file, 'r') as f:
             spikeinterface_info = json.load(f)
-        if spikeinterface_info.get("object") != "SortingAnalyzer":
-            return False
-        else:
-            return True
+        return spikeinterface_info.get("object") == "SortingAnalyzer"
     else:  #zarr folder
         import zarr
         # Check if the folder contains the necessary files for a SortingAnalyzer
@@ -304,10 +301,7 @@ def check_folder_is_analyzer(folder):
         spikeinterface_info = zarr_root.attrs.get('spikeinterface_info')
         if spikeinterface_info is None:
             return False
-        if spikeinterface_info.get("object") != "SortingAnalyzer":
-            return False
-        else:
-            return True
+        return spikeinterface_info.get("object") == "SortingAnalyzer"
         
 
 def run_mainwindow_cli():

--- a/spikeinterface_gui/view_base.py
+++ b/spikeinterface_gui/view_base.py
@@ -252,9 +252,7 @@ class ViewBase:
             from .myqt import QT
 
             active_window = QT.QApplication.activeWindow()
-            if active_window and isinstance(active_window, QT.QMessageBox):
-                return True
-            return False
+            return isinstance(active_window, QT.QMessageBox)
         elif self.backend == "panel":
             return self._panel_warning_active
 


### PR DESCRIPTION
## Summary

Seeing those code patterns triggerred me ;)

Small readability cleanup: replace several `if cond: return True else: return False` (and the inverse) constructs with a direct `return cond` (or `return not cond`, or a swapped `==`/`!=`). No behavior change.

## Commits

- 5731ace `Simplify if cond: return True/False else: return False/True patterns`

<details><summary>Per-commit details</summary>

### 5731ace `Simplify if cond: return True/False else: return False/True patterns`

Refactored 6 instances across 3 files:

- `spikeinterface_gui/curationview.py` — 3 methods (`_conditional_refresh_merge` / `_delete` / `_split`): `if cond: return True else: return False` → `return cond`.
- `spikeinterface_gui/main.py` (the SortingAnalyzer-folder check, both the non-zarr and zarr branches): `if X != Y: return False else: return True` → `return X == Y` (swapped `!=` to `==`).
- `spikeinterface_gui/view_base.py` (`is_warning_active`): `if active_window and isinstance(active_window, QT.QMessageBox): return True; return False` → `return isinstance(active_window, QT.QMessageBox)`. `isinstance(None, ...)` already returns `False`, so the truthiness guard was redundant.

Left `controller.py:check_is_view_possible` alone because its `if`-branch has a side-effecting `print`, so the pattern doesn't simplify cleanly.

</details>

## Test plan

- [x] `python -m py_compile` on the three edited files
- [x] Reviewer: spot-check the `is_warning_active` simplification — relying on `isinstance(None, ...)` being False
