### PR TITLE
Tune codespell: move workflow's ignore list into pyproject.toml

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -19,9 +19,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Annotate locations with typos
-        uses: codespell-project/codespell-problem-matcher@v1
       - name: Codespell
         uses: codespell-project/actions-codespell@v2
-        with:
-          ignore_words_list: sortings,trough

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,4 +71,8 @@ docs = [
 skip = '.git*,pyproject.toml'
 check-hidden = true
 # ignore-regex = ''
-ignore-words-list = 'nd,gaus'
+# nd       - short for "2nd" (loop variable)
+# gaus     - short for "Gaussian"
+# sortings - plural of `Sorting` objects (variable name, not a typo for "sorting")
+# trough   - waveform trough; a real spike-sorting term (not a typo for "through")
+ignore-words-list = 'nd,gaus,sortings,trough'


### PR DESCRIPTION
The Codespell CI workflow had `ignore_words_list: sortings,trough` baked into the YAML, which is only applied in CI. Running `codespell` locally (or via any other integration) flagged 7 hits for these words that CI silently suppressed — both `sortings` (plural of `Sorting` objects) and `trough` (waveform trough, a real spike-sorting term) are legitimate domain terms, not typos.

Move them into `[tool.codespell].ignore-words-list` in pyproject.toml so the config is the single source of truth, and add inline comments explaining each entry. Drop the redundant override and the `codespell-problem-matcher` step from the workflow (problem-matcher annotations are built into `actions-codespell@v2`).

Verified: `uvx codespell` exits 0 on the tree.