### PR TITLE
feat: extend scatter range  behavior

### DIFF
--- a/spikeinterface_gui/amplitudescalingsview.py
+++ b/spikeinterface_gui/amplitudescalingsview.py
@@ -9,6 +9,15 @@ class AmplitudeScalingsView(BaseScatterView):
         y_label = "Amplitude scaling"
         spike_data = controller.amplitude_scalings
 
+        # Overwrite "range_type", "range_min", and "range_max"so that default range is 0 - 2
+        for setting in AmplitudeScalingsView._settings:
+            if setting['name'] == 'range_type':
+                setting['value'] = 'absolute'
+            elif setting['name'] == 'range_min':
+                setting['value'] = 0.0
+            elif setting['name'] == 'range_max':
+                setting['value'] = 2.0
+
         BaseScatterView.__init__(
             self,
             controller=controller,

--- a/spikeinterface_gui/backend_panel.py
+++ b/spikeinterface_gui/backend_panel.py
@@ -1,3 +1,5 @@
+import warnings
+
 import param
 import panel as pn
 import numpy as np
@@ -248,9 +250,10 @@ class PanelMainWindow:
                 for setting_name, user_setting in user_settings.get(view_name).items():
                     available_settings = [s["name"] for s in view_class._settings]
                     if setting_name not in available_settings:
-                        raise KeyError(f"Setting {setting_name} is not a valid setting for View {view_name}. Check your settings file.")
-                    settings_index = available_settings.index(setting_name)
-                    view_class._settings[settings_index]["value"] = user_setting
+                        warnings.warn(f"Setting {setting_name} is not a valid setting for View {view_name}. Ignoring setting. Check your settings file.")
+                    else:
+                        settings_index = available_settings.index(setting_name)
+                        view_class._settings[settings_index]["value"] = user_setting
 
             view = view_class(controller=self.controller, parent=None, backend='panel')
             self.views[view_name] = view

--- a/spikeinterface_gui/backend_qt.py
+++ b/spikeinterface_gui/backend_qt.py
@@ -1,3 +1,5 @@
+import warnings
+
 from .myqt import QT
 import pyqtgraph as pg
 import markdown
@@ -203,10 +205,11 @@ class QtMainWindow(QT.QMainWindow):
             if user_settings is not None and view_name != 'mainsettings' and user_settings.get(view_name) is not None:
                 for setting_name, user_setting in user_settings.get(view_name).items():
                     if setting_name not in view.settings.keys().keys():
-                        raise KeyError(f"Setting {setting_name} is not a valid setting for View {view_name}. Check your settings file.")
-                    stop_listen_setting_changes(view)
-                    view.settings[setting_name] = user_setting
-                    listen_setting_changes(view)
+                        warnings.warn(f"Setting {setting_name} is not a valid setting for View {view_name}. Ignoring setting. Check your settings file.")
+                    else:
+                        stop_listen_setting_changes(view)
+                        view.settings[setting_name] = user_setting
+                        listen_setting_changes(view)
 
 
             widget.set_view(view)

--- a/spikeinterface_gui/basescatterview.py
+++ b/spikeinterface_gui/basescatterview.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from matplotlib.path import Path as mpl_path
 
@@ -58,6 +59,15 @@ class BaseScatterView(ViewBase):
 
         # avoid clear outliers in the plot and histogram by using percentiles
         if self.settings['range_type'] == 'percentiles':
+            if self.settings["range_min"] < 0:
+                warnings.warn("range_min cannot be less than 0. Setting it to 0.")
+                self.settings["range_min"] = 0.0
+            if self.settings["range_max"] > 100:
+                warnings.warn("range_max cannot be greater than 100. Setting it to 100.")
+                self.settings["range_max"] = 100.0
+            if self.settings["range_min"] > self.settings["range_max"]:
+                warnings.warn("range_min cannot be greater than range_max. Setting range_min to range_max.")
+                self.settings["range_min"] = self.settings["range_max"] - 1
             ymin, ymax = np.percentile(spike_data, [self.settings['range_min'], self.settings['range_max']])
         else:
             ymin, ymax = self.settings['range_min'], self.settings['range_max']

--- a/spikeinterface_gui/basescatterview.py
+++ b/spikeinterface_gui/basescatterview.py
@@ -14,8 +14,9 @@ class BaseScatterView(ViewBase):
             {'name': 'alpha', 'type': 'float', 'value' : 0.7, 'limits':(0, 1.), 'step':0.05},
             {'name': 'scatter_size', 'type': 'float', 'value' : 2., 'step':0.5},
             {'name': 'num_bins', 'type': 'int', 'value' : 30, 'step': 1},
-            {'name': 'display_low_percentiles', 'type': 'float', 'value' : 2.0, 'limits':(0, 50), 'step':0.5},
-            {'name': 'display_high_percentiles', 'type': 'float', 'value' : 98.0, 'limits':(50, 100), 'step':0.5},
+            {'name': 'range_type', 'type': 'list', 'limits': ['percentiles', 'absolute']},
+            {'name': 'range_min', 'type': 'float', 'value' : 1.0},
+            {'name': 'range_max', 'type': 'float', 'value' : 99.0},
         ]
     _need_compute = False
 
@@ -56,7 +57,10 @@ class BaseScatterView(ViewBase):
             return spike_times, spike_data, np.array([1]), np.array([ymin, ymax]), ymin, ymax, inds
 
         # avoid clear outliers in the plot and histogram by using percentiles
-        ymin, ymax = np.percentile(spike_data, [self.settings['display_low_percentiles'], self.settings['display_high_percentiles']])
+        if self.settings['range_type'] == 'percentiles':
+            ymin, ymax = np.percentile(spike_data, [self.settings['range_min'], self.settings['range_max']])
+        else:
+            ymin, ymax = self.settings['range_min'], self.settings['range_max']
         min_bin_size = np.min(np.diff(np.unique(spike_data)))
         bins = np.linspace(ymin, ymax, self.settings['num_bins'])
         # if bins are too small, adjust the number of bins to ensure a minimum bin size and avoid jumps in the histogram

--- a/spikeinterface_gui/basescatterview.py
+++ b/spikeinterface_gui/basescatterview.py
@@ -66,10 +66,13 @@ class BaseScatterView(ViewBase):
                 warnings.warn("range_max cannot be greater than 100. Setting it to 100.")
                 self.settings["range_max"] = 100.0
             if self.settings["range_min"] > self.settings["range_max"]:
-                warnings.warn("range_min cannot be greater than range_max. Setting range_min to range_max.")
+                warnings.warn("range_min cannot be greater than range_max. Setting range_min to range_max - 1.")
                 self.settings["range_min"] = self.settings["range_max"] - 1
             ymin, ymax = np.percentile(spike_data, [self.settings['range_min'], self.settings['range_max']])
         else:
+            if self.settings["range_min"] > self.settings["range_max"]:
+                warnings.warn("range_min cannot be greater than range_max. Setting range_min to range_max - 1.")
+                self.settings["range_min"] = self.settings["range_max"] - 1
             ymin, ymax = self.settings['range_min'], self.settings['range_max']
         min_bin_size = np.min(np.diff(np.unique(spike_data)))
         bins = np.linspace(ymin, ymax, self.settings['num_bins'])


### PR DESCRIPTION
Give the option to choose the range behavior with:

- `range_type`: percentile / absolute
- `range_min` / `range_max`: depending on `range_type` will be percentile or abs limits!

Default is now: percentile (1, 99)